### PR TITLE
Use system time zone instead of assuming Zulu time (UTC)

### DIFF
--- a/src/main/java/mu/semte/ch/lib/utils/ModelUtils.java
+++ b/src/main/java/mu/semte/ch/lib/utils/ModelUtils.java
@@ -15,6 +15,7 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.ZoneId;
 import java.util.UUID;
 
 
@@ -31,7 +32,9 @@ public interface ModelUtils {
     }
 
     static String formattedDate(LocalDateTime ldt) {
-        return DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.000'Z'").format(ldt);
+        return DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(
+            ldt.atZone(ZoneId.systemDefault())
+        );
     }
 
     static boolean equals(Model firstModel, Model secondModel) {


### PR DESCRIPTION
Changed date format. 'Z' in iso 8601 means Zulu Time i.e. UTC.
This change adds the system time zone instead.